### PR TITLE
Issue #41: Add test for backquote alone on the line

### DIFF
--- a/core/src/test/java/org/tautua/markdownpapers/MarkdownPapersTest.java
+++ b/core/src/test/java/org/tautua/markdownpapers/MarkdownPapersTest.java
@@ -33,6 +33,7 @@ public class MarkdownPapersTest extends BaseTest {
     @Parameters
     public static List<Object[]> data() throws FileNotFoundException {
         return Arrays.asList(new Object[][]{
+                {"backquoteAlone"},
                 {"code"},
                 {"comments"},
                 {"emphasis"},

--- a/core/src/test/resources/others/backquoteAlone.html
+++ b/core/src/test/resources/others/backquoteAlone.html
@@ -1,0 +1,3 @@
+<p><code>
+Quote alone
+</code></p>

--- a/core/src/test/resources/others/backquoteAlone.text
+++ b/core/src/test/resources/others/backquoteAlone.text
@@ -1,0 +1,3 @@
+`
+Quote alone
+`


### PR DESCRIPTION
Backquotes are handled properly by the MarkdownPapers,
only backquote standing alone on a line is not converted
into a corresponding `<code>` block.
